### PR TITLE
Install NodeJS first 

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
 source 'https://supermarket.chef.io'
-
+cookbook 'nodejs', git: 'https://github.com/taliesins/nodejs', branch: 'Windows'
 metadata

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
 source 'https://supermarket.chef.io'
-cookbook 'nodejs', git: 'https://github.com/taliesins/nodejs', branch: 'Windows'
+cookbook 'nodejs', git: 'https://github.com/taliesins/nodejs', branch: 'windows'
 metadata

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,8 +24,8 @@ end
 
 url = node['iisnode']['store']['url'] + package_name
 
+include_recipe "nodejs"
 include_recipe 'iis_urlrewrite'
-
 windows_package 'iisnode' do
   checksum checksum
   source url


### PR DESCRIPTION
Install NodeJS first as it's a dependency.

References a fork of the nodejs cookbook as we need the submit a PR upstream to add windows compatibility.