### PR TITLE
Install NodeJS first

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
 source 'https://supermarket.chef.io'
-
+cookbook 'nodejs', git: 'https://github.com/taliesins/nodejs', branch: 'Windows'
 metadata

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
 source 'https://supermarket.chef.io'
-cookbook 'nodejs', git: 'https://github.com/taliesins/nodejs', branch: 'Windows'
+cookbook 'nodejs', git: 'https://github.com/taliesins/nodejs', branch: 'windows'
 metadata

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ clone_depth: 1
 
 # Install the latest nightly of ChefDK
 install:
-  - ps: iex (irm https://omnitruck.chef.io/install.ps1); Install-Project -Project chefdk -channel current
+  - ps: (& cmd /c); iex (irm https://omnitruck.chef.io/install.ps1); Install-Project -Project chefdk -channel current
   - ps: 'Get-CimInstance win32_operatingsystem -Property Caption, OSArchitecture, Version | fl Caption, OSArchitecture, Version'
   - ps: $PSVersionTable
   - c:\opscode\chefdk\bin\chef.bat exec ruby --version

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,7 +24,7 @@ end
 
 url = node['iisnode']['store']['url'] + package_name
 
-include_recipe "nodejs"
+include_recipe 'nodejs'
 include_recipe 'iis_urlrewrite'
 windows_package 'iisnode' do
   checksum checksum

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,7 +25,7 @@ end
 url = node['iisnode']['store']['url'] + package_name
 
 include_recipe 'nodejs'
-include_recipe 'iis_urlrewrite'
+#include_recipe 'iis_urlrewrite'
 windows_package 'iisnode' do
   checksum checksum
   source url

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,8 +24,8 @@ end
 
 url = node['iisnode']['store']['url'] + package_name
 
+include_recipe "nodejs"
 include_recipe 'iis_urlrewrite'
-
 windows_package 'iisnode' do
   checksum checksum
   source url

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,7 +25,7 @@ end
 url = node['iisnode']['store']['url'] + package_name
 
 include_recipe 'nodejs'
-#include_recipe 'iis_urlrewrite'
+include_recipe 'iis_urlrewrite'
 windows_package 'iisnode' do
   checksum checksum
   source url


### PR DESCRIPTION
Install NodeJS first as it's a dependency.

References a fork of the nodejs cookbook as we need the submit a PR upstream to add windows compatibility.